### PR TITLE
Add case-insensitive string comparison for $last and $divoutput paramete...

### DIFF
--- a/wf-includes/wf-display-functions.php
+++ b/wf-includes/wf-display-functions.php
@@ -547,7 +547,7 @@ class wflux_display_css extends wflux_display_code {
 		$wf_single = $this->wfx_columns_width;
 
 		//Last class added only if == Y
-		$last = ( $last == 'Y' ) ? ' last' : '';
+		$last = ( 0 === strcasecmp( $last, 'Y' ) ) ? ' last' : '';
 
 		// Prepare extra CSS classes string for display if supplied
 		$class_clean = ( $class !='' ) ? ' ' . wp_kses( $class, '' ) : '';
@@ -559,7 +559,7 @@ class wflux_display_css extends wflux_display_code {
 		// It encloses the dynamic size class in '<div' and '>' for you
 		// Sugest you dont use this at get_template_part xhtml code level as you want to see clearly where the divs open and close
 		// Could be used in get_template_part code blocks
-		if ($divoutput == 'Y') {
+		if ( 0 === strcasecmp( $divoutput, 'Y') ) {
 			$divout_open_clean = '<div ';
 			$divout_close_clean = '>';
 		} else {


### PR DESCRIPTION
...rs - allows 'y' or 'Y' to be passed and still work!

Found an issue where the 'last' css class was not being added to the sidebar div when specifying the sidebar to be on the right, causing it to drop down beneath the content. The call to wf_css was passing 'y' whereas 'Y' was expected!

Noticed that the option for $divoutput may also hit the same problem, so changed that one too!

Cheers,
Rik
